### PR TITLE
Removed extra package from requirements.txt

### DIFF
--- a/package.py
+++ b/package.py
@@ -13,4 +13,6 @@ print(stdout.decode('utf-8'))
 
 
 with open('requirements.txt', 'w') as requirementsWriter:
-    requirementsWriter.write(stdout.decode('utf-8'))
+    # Remove invalid package 'pkg-resources==0.0.0' (Ubuntu/pip bug)
+    packages = stdout.decode('utf-8').replace('pkg-resources==0.0.0','')
+    requirementsWriter.write(packages)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ autopep8==1.4.4
 isort==4.3.21
 lazy-object-proxy==1.4.3
 mccabe==0.6.1
-pkg-resources==0.0.0
 pycodestyle==2.5.0
 pylint==2.4.4
 PyYAML==5.3


### PR DESCRIPTION
`pip install` command fails due to extra package in `requirements.txt`. 

See:
https://stackoverflow.com/questions/39577984/what-is-pkg-resources-0-0-0-in-output-of-pip-freeze-command